### PR TITLE
Update wpa_supplicant.conf for OPNsense 24.7 Compatibility

### DIFF
--- a/wpa/wpa_supplicant.conf
+++ b/wpa/wpa_supplicant.conf
@@ -1,9 +1,10 @@
 eapol_version=1
 ap_scan=0
 fast_reauth=1
+openssl_ciphers=DEFAULT@SECLEVEL=0
 network={
 	eap=TLS
 	eapol_flags=0
 	key_mgmt=IEEE8021X
-	phase1="allow_canned_success=1"
+	phase1="allow_canned_success=1" allow_unsafe_renegotiation=1"
 }


### PR DESCRIPTION
Updates the wpa_supplicant configuration to restore functionality to the supplicant bypass method

Based off findings by @jeholliday posted at https://forum.opnsense.org/index.php?topic=41730.msg206938#msg206938